### PR TITLE
Bypass admin approval 

### DIFF
--- a/raven.admin.inc
+++ b/raven.admin.inc
@@ -43,7 +43,7 @@ function raven_settings_form($form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Enable administrator approval override'),
     '#default_value' => variable_get('raven_override_administrator_approval'),
-    '#description' => t('Override the Drupal administrator approval settings for users succesfully authenticated by Raven.'),
+    '#description' => t('Override the Drupal administrator approval settings for users successfully authenticated by Raven.'),
   );
 
   // Log users out when closing the browser?

--- a/raven.info
+++ b/raven.info
@@ -2,7 +2,7 @@ name = Raven authentication
 description = Allows users to authenticate with Raven.
 core = 7.x
 package = University of Cambridge
-version = 7.x-1.0-dev-patched-AlexCorr
+version = 7.x-1.0-dev
 configure = admin/config/people/raven
 
 dependencies[] = user

--- a/raven.install
+++ b/raven.install
@@ -33,7 +33,7 @@ function raven_install() {
   variable_set('raven_website_description', NULL);
   variable_set('raven_login_fail_redirect', NULL);
   variable_set('raven_logout_on_browser_close', TRUE);
-  variable_set('raven_override_administrator_approval', TRUE);
+  variable_set('raven_override_administrator_approval', FALSE);
 }
 
 /**
@@ -46,7 +46,7 @@ function raven_uninstall() {
   variable_del('raven_website_description');
   variable_del('raven_login_fail_redirect');
   variable_del('raven_logout_on_browser_close');
-  variable_set('raven_override_administrator_approval');
+  variable_del('raven_override_administrator_approval');
 
   // Delete authmap entries
   db_delete('authmap')


### PR DESCRIPTION
Overriding Drupal's admin approval setting by automatically activating successfully raven authenticated accounts.
