### PR TITLE
urlencode site description

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -151,7 +151,7 @@ function raven_login($redirect = NULL) {
 
   $params['ver'] = '2';
   $params['url'] = url('raven/auth', array('absolute' => TRUE));
-  $params['desc'] = variable_get('raven_website_description', variable_get('site_name', $base_url));
+  $params['desc'] = urlencode(variable_get('raven_website_description', variable_get('site_name', $base_url)));
   $params['params'] = urlencode(url($redirect, array('absolute' => TRUE)));
 
   $parameters = array();


### PR DESCRIPTION
Raven logins fail if site name/decription contain characters (e.g. ampersands) that need to be urlencoded
