### PR TITLE
Redirect if no WLS-Response is present

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -173,6 +173,10 @@ function raven_login($redirect = NULL) {
  * Failed attempts send the user to the login failure redirect path and logs the problem.
  */
 function raven_auth() {
+  if (FALSE === isset($_REQUEST['WLS-Response'])) {
+    drupal_goto(variable_get('raven_login_fail_redirect'));
+  }
+
   // Parse Raven Reply
   $parts = explode('!', $_REQUEST['WLS-Response']);
 


### PR DESCRIPTION
If you go to `/raven/auth` manually you currently get three notices:
- Warning: Notice: Undefined index: WLS-Response in raven_auth()
- Warning: Suspicious login attempt denied and logged.
- Warning: Notice: Undefined index: WLS-Response in raven_auth()

This checks to see the the `WLS-Response` query string parameter is set, and, if not, immediately redirects to the failure page.
