### PR TITLE
Override aliased paths

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -314,7 +314,7 @@ function raven_init() {
 
   // prevent normal login pages if needed
   if (variable_get('raven_login_override', FALSE)) {
-    switch (strtolower(request_path())) {
+    switch (strtolower(current_path())) {
       case 'user':
         if (!$user->uid) {
           raven_login('user');


### PR DESCRIPTION
`request_path()` returns the request form, which includes language-prefixed paths. `current_path()` uses the real un-aliased path, which fixes #21.
