### PR TITLE
Remove separate authentication page and use the front page instead

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -55,13 +55,6 @@ function raven_menu() {
     'type' => MENU_CALLBACK,
   );
 
-  $items['raven/auth'] = array(
-    'title' => 'Raven authentication',
-    'access callback' => TRUE,
-    'page callback' => 'raven_auth',
-    'type' => MENU_CALLBACK,
-  );
-
   $items['admin/config/people/raven'] = array(
     'title' => 'Raven authentication',
     'description' => 'Settings to configure logging in with Raven',
@@ -100,11 +93,8 @@ function raven_permission() {
 function raven_menu_site_status_alter(&$menu_site_status, $path) {
   if (
     $menu_site_status === MENU_SITE_OFFLINE &&
-    user_is_anonymous() && (
-      $path === 'raven/login' ||
-      $path === 'raven/auth' ||
-      ($path === 'user/backdoor/login' && raven_backdoor_login_is_enabled())
-    )
+    user_is_anonymous() &&
+    ($path === 'raven/login' || ($path === 'user/backdoor/login' && raven_backdoor_login_is_enabled()))
   ) {
     $menu_site_status = MENU_SITE_ONLINE;
   }
@@ -152,7 +142,7 @@ function raven_login($redirect = NULL) {
   }
 
   $params['ver'] = '3';
-  $params['url'] = url('raven/auth', array('absolute' => TRUE));
+  $params['url'] = urlencode($base_url . '/');
   $params['desc'] = urlencode(variable_get('raven_website_description', variable_get('site_name', $base_url)));
   $params['params'] = urlencode(url($redirect, array('absolute' => TRUE)));
 
@@ -173,6 +163,8 @@ function raven_login($redirect = NULL) {
  * Failed attempts send the user to the login failure redirect path and logs the problem.
  */
 function raven_auth() {
+  global $base_url;
+
   if (FALSE === isset($_REQUEST['WLS-Response'])) {
     drupal_goto(variable_get('raven_login_fail_redirect'));
   }
@@ -221,11 +213,11 @@ function raven_auth() {
     }
 
     // Valid path check
-    if ($r_url !== url('raven/auth', array('absolute' => TRUE))) {
+    if ($r_url !== $base_url . '/') {
       drupal_set_message(t('Suspicious login attempt denied and logged.'), 'error');
       watchdog('raven', 'Suspicious login attempt claiming to be @raven_id. \'url\' validation failed: expecting \'@expected\', got \'@given\'.', array(
         '@raven_id' => $r_principal,
-        '@expected' => url('raven/auth', array('absolute' => TRUE)),
+        '@expected' => $base_url . '/',
         '@given' => $r_url,
       ), WATCHDOG_ALERT);
       drupal_goto(variable_get('raven_login_fail_redirect'));
@@ -337,6 +329,10 @@ function raven_init() {
         }
         break;
     }
+  }
+
+  if (isset($_REQUEST['WLS-Response'])) {
+    raven_auth();
   }
 }
 

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -182,7 +182,7 @@ class FeatureContext extends RawMinkContext {
    * @Given /^I have a Raven response with an? "([^"]*)" problem$/
    */
   public function iHaveARavenResponseWithAProblem($problem) {
-    $url = rtrim($this->getMinkParameter('base_url'), '/') . '/raven/auth';
+    $url = rtrim($this->getMinkParameter('base_url'), '/') . '/';
 
     if (FALSE === in_array($problem, array('kid', 'url', 'auth', 'sso', 'invalid', 'incomplete', 'expired'))) {
       throw new Exception('Unknown problem');

--- a/tests/features/login_failure.feature
+++ b/tests/features/login_failure.feature
@@ -10,11 +10,17 @@ Feature: Raven failure
 
   Scenario: Redirects on failure
     Given the "raven_login_fail_redirect" variable is set to "foo"
-    When I go to "/raven/auth"
+    When I go to "/?WLS-Response"
     Then I should be on "/foo"
 
   Scenario: Pressing cancel fails gracefully
     Given I am on "/raven/login"
+    When I press "Cancel"
+    Then I should see "Raven authentication cancelled"
+
+  Scenario: Pressing cancel fails gracefully when clean URLs are disabled
+    Given the "clean_url" variable is set to "FALSE"
+    And I am on "/?q=raven/login"
     When I press "Cancel"
     Then I should see "Raven authentication cancelled"
 


### PR DESCRIPTION
Having a separate authentication page is unnecessary, just looking for the `WLS-Response` query string parameter on the front page is sufficient. Fixes #27.
