### PR TITLE
Show correct field prefix when not using clean URLs

### DIFF
--- a/raven.admin.inc
+++ b/raven.admin.inc
@@ -83,7 +83,7 @@ function raven_settings_form($form, &$form_state) {
   $form['raven_login_fail_redirect'] = array(
     '#type' => 'textfield',
     '#title' => t('Login failure redirect'),
-    '#field_prefix' => $base_url . '/',
+    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . (variable_get('clean_url', FALSE) ? '' : '?q='),
     '#default_value' => variable_get('raven_login_fail_redirect'),
     '#description' => t('If a login fails, they will be redirected to this page.'),
     '#required' => FALSE,

--- a/tests/features/login_failure.feature
+++ b/tests/features/login_failure.feature
@@ -1,12 +1,19 @@
 Feature: Raven failure
 
-  Scenario: Can configure Raven failure redirect path
-    Given the "raven_login_fail_redirect" variable is set to "NULL"
+  Scenario Outline: Can configure Raven failure redirect path
+    Given the "clean_url" variable is set to "<clean url>"
+    And the "raven_login_fail_redirect" variable is set to "NULL"
     And I am logged in as the admin user
-    And I am on "/admin/config/people/raven"
+    And I am on "<config page>"
+    Then I should see the base URL in the "label:contains('Login failure redirect') + .field-prefix" element
     When I fill in "Login failure redirect" with "foo"
     And I press "Save configuration"
     Then the "raven_login_fail_redirect" variable should be "foo"
+
+  Examples:
+    | clean url | config page                  |
+    | TRUE      | /admin/config/people/raven   |
+    | FALSE     | ?q=admin/config/people/raven |
 
   Scenario: Redirects on failure
     Given the "raven_login_fail_redirect" variable is set to "foo"


### PR DESCRIPTION
When not using clean URLs the login failure redirect field currently has a prefix of something like `http://localhost/drupal/`, whereas things like the 403 redirect have the correct `http://localhost/drupal/?q=`.
