### PR TITLE
Fix website description after saving config form

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -141,9 +141,11 @@ function raven_login($redirect = NULL) {
     $redirect = ($_SERVER['HTTP_REFERER'] != NULL ? $_SERVER['HTTP_REFERER'] : $base_url);
   }
 
+  $website_description = variable_get('raven_website_description');
+
   $params['ver'] = '3';
   $params['url'] = urlencode($base_url . '/');
-  $params['desc'] = urlencode(variable_get('raven_website_description', variable_get('site_name', $base_url)));
+  $params['desc'] = urlencode(!empty($website_description) ? $website_description : variable_get('site_name', $base_url));
   $params['params'] = urlencode(url($redirect, array('absolute' => TRUE)));
 
   $parameters = array();

--- a/tests/features/bootstrap/functions.php
+++ b/tests/features/bootstrap/functions.php
@@ -17,6 +17,10 @@ function is_serialized($value) {
   $length = strlen($value);
   $end = '';
 
+  if ($length === 0) {
+    return FALSE;
+  }
+
   switch ($value[0]) {
     case 's':
       if ($value[$length - 2] !== '"') {

--- a/tests/features/website_description.feature
+++ b/tests/features/website_description.feature
@@ -10,10 +10,17 @@ Feature: Website description
 
   Scenario: Uses site name when not set
     Given the "site_name" variable is set to "My Site Name"
+    And the "raven_website_description" variable is set to "NULL"
     When I go to "/raven/login"
     Then I should see "My Site Name"
 
-  Scenario: Uses website description when site
+  Scenario: Uses site name when an empty string
+    Given the "site_name" variable is set to "My Site Name"
+    And the "raven_website_description" variable is set to ""
+    When I go to "/raven/login"
+    Then I should see "My Site Name"
+
+  Scenario: Uses website description over site name
     Given the "site_name" variable is set to "My Site Name"
     And the "raven_website_description" variable is set to "Website Description"
     When I go to "/raven/login"
@@ -22,5 +29,11 @@ Feature: Website description
 
   Scenario: Encodes website description
     Given the "raven_website_description" variable is set to "Foo & Bar"
+    When I go to "/raven/login"
+    Then I should see "Foo & Bar"
+
+  Scenario: Encodes site name
+    Given the "site_name" variable is set to "Foo & Bar"
+    And the "raven_website_description" variable is set to "NULL"
     When I go to "/raven/login"
     Then I should see "Foo & Bar"


### PR DESCRIPTION
By default the website description is set to `null` so that site name is used. When saving the config form and the description field is empty it becomes an empty string, causing an empty string to be given to Raven instead of the site name.
