### PR TITLE
Validate the login failure redirect path

### DIFF
--- a/raven.admin.inc
+++ b/raven.admin.inc
@@ -89,5 +89,21 @@ function raven_settings_form($form, &$form_state) {
     '#required' => FALSE,
   );
 
+  $form['#validate'][] = 'raven_settings_validate';
+
   return system_settings_form($form);
+}
+
+/**
+ * Validator for the raven_settings_form() form.
+ */
+function raven_settings_validate($form, &$form_state) {
+  // Get the normal path of login failure redirect.
+  if (!empty($form_state['values']['raven_login_fail_redirect'])) {
+    form_set_value($form['raven_login_fail_redirect'], drupal_get_normal_path($form_state['values']['raven_login_fail_redirect']), $form_state);
+  }
+  // Validate login failure redirect path.
+  if (!empty($form_state['values']['raven_login_fail_redirect']) && !drupal_valid_path($form_state['values']['raven_login_fail_redirect'])) {
+    form_set_error('raven_login_fail_redirect', t("The path '%path' is either invalid or you do not have access to it.", array('%path' => $form_state['values']['raven_login_fail_redirect'])));
+  }
 }

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -276,6 +276,21 @@ class FeatureContext extends RawMinkContext {
   }
 
   /**
+   * @Given /^the "([^"]*)" path has the alias "([^"]*)"$/
+   */
+  public function thePathHasTheAlias($path, $alias) {
+    $minkContext = $this->getMinkContext();
+
+    $this->iAmLoggedInAsTheAdminUser();
+    $minkContext->visit('/admin/config/search/path/add');
+    $minkContext->fillField('Existing system path', $path);
+    $minkContext->fillField('Path alias', $alias);
+    $minkContext->pressButton('Save');
+
+    $minkContext->assertPageContainsText('The alias has been saved.');
+  }
+
+  /**
    * @Then /^I should see an? "([^"]*)" "([^"]*)" Watchdog message "([^"]*)"$/
    */
   public function iShouldSeeAWatchdogMessage($severity, $type, $message) {

--- a/tests/features/login_failure.feature
+++ b/tests/features/login_failure.feature
@@ -6,14 +6,31 @@ Feature: Raven failure
     And I am logged in as the admin user
     And I am on "<config page>"
     Then I should see the base URL in the "label:contains('Login failure redirect') + .field-prefix" element
-    When I fill in "Login failure redirect" with "foo"
+    When I fill in "Login failure redirect" with "node"
     And I press "Save configuration"
-    Then the "raven_login_fail_redirect" variable should be "foo"
+    Then the "raven_login_fail_redirect" variable should be "node"
 
   Examples:
     | clean url | config page                  |
     | TRUE      | /admin/config/people/raven   |
     | FALSE     | ?q=admin/config/people/raven |
+
+  Scenario: Raven failure redirect path has to be valid
+    Given I am logged in as the admin user
+    And I am on "/admin/config/people/raven"
+    When I fill in "Login failure redirect" with "foo"
+    And I press "Save configuration"
+    Then I should see "The path 'foo' is either invalid or you do not have access to it."
+
+  Scenario: Raven failure redirect path stores unaliased path
+    Given the "path" module is enabled
+    And the "node" path has the alias "foo"
+    And I am logged in as the admin user
+    And I am on "/admin/config/people/raven"
+    When I fill in "Login failure redirect" with "foo"
+    And I press "Save configuration"
+    Then the "raven_login_fail_redirect" variable should be "node"
+    And the "Login failure redirect" field should contain "node"
 
   Scenario: Redirects on failure
     Given the "raven_login_fail_redirect" variable is set to "foo"


### PR DESCRIPTION
Currently the login failure redirect path is just a free text field. This adds in validation so that it has to be a real path.
