### PR TITLE
Add option to redirect succesful logins based upon the requested URI

### DIFF
--- a/raven.admin.inc
+++ b/raven.admin.inc
@@ -89,6 +89,15 @@ function raven_settings_form($form, &$form_state) {
     '#required' => FALSE,
   );
 
+  // Let the user override the standard login pages (user, user/login, ?q=user, ?q=user/login)
+  $form['raven_use_request_uri'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Redirect successful logins to $_SERVER[\'REQUEST_URI\']'),
+    '#default_value' => variable_get('raven_use_request_uri'),
+    '#description' => t('Preferentially redirect successful logins to the requested URI. This lets you set the site\'s 403 page at admin/system/site-information to raven/login.'),
+  );
+
+
   $form['#validate'][] = 'raven_settings_validate';
 
   return system_settings_form($form);

--- a/raven.module
+++ b/raven.module
@@ -34,7 +34,6 @@ function raven_help($path, $arg) {
         '@user1' => $user1 ? $user1->name : 'admin',
         // user 1 should always exist, but just in case
       )) . '</dd>';
-
       $output .= '</dl>';
       break;
   }
@@ -137,8 +136,25 @@ function raven_backdoor_login() {
 function raven_login($redirect = NULL) {
   global $base_url;
 
-  if ($redirect === NULL) {
-    $redirect = ($_SERVER['HTTP_REFERER'] != NULL ? $_SERVER['HTTP_REFERER'] : $base_url);
+	$use_request_uri = variable_get('raven_use_request_uri', FALSE);
+
+	if($use_request_uri) {
+		$protocol = stripos($_SERVER['SERVER_PROTOCOL'],'https') === true ? 'https://' : 'http://';
+		# Need to cope with the case that $base_url and SERVER_NAME are not the same, e.g.
+		# site is behind reverse proxy and we have something like:
+		#  $_SERVER['SERVER_NAME'] = www.example.com
+		#  $base_url = www.example.com/mysite
+		#  $_SERVER['REQUEST_URI'] = /mysite/content/index
+		$requested_url = $protocol.$_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
+		$relative_path = str_replace($base_url, "", $requested_url);
+	}
+
+	if ($redirect === NULL) {
+		if($use_request_uri == TRUE && $relative_path != '/raven/login') {
+			$redirect = $requested_url;
+		} else {
+			$redirect = ($_SERVER['HTTP_REFERER'] != NULL ? $_SERVER['HTTP_REFERER'] : $base_url);
+		}
   }
 
   $website_description = variable_get('raven_website_description');
@@ -148,6 +164,11 @@ function raven_login($redirect = NULL) {
   $params['desc'] = !empty($website_description) ? $website_description : variable_get('site_name', $base_url);
   $params['params'] = url($redirect, array('absolute' => TRUE));
 
+	if($use_request_uri == TRUE) { 
+	# drupal_goto will ignore our requested path if $_GET['destination'] is set. However, we really really
+	# want to go to $redirect which we constructed above 
+		unset($_GET['destination']);
+	}
   drupal_goto(get_raven_url(), array('query' => $params), 303);
 }
 


### PR DESCRIPTION
With this patch, an option is added to redirect succesful Raven logins to the requested uri. This enables the following:
- admin sets the site 403 page to raven/login
- user clicks on a link to a page which they are not authorized to view
- user is automtically redirected to the Raven login page
- upon succesful authentication, they are redirected back to the requested page

The user will then either see the page, if authorized, or Drupal will return a generic "not authorized" message if not.
