### PR TITLE
Cater for destination query string paremeter when using drupal_goto()

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -138,7 +138,15 @@ function raven_login($redirect = NULL) {
   global $base_url;
 
   if ($redirect === NULL) {
-    $redirect = ($_SERVER['HTTP_REFERER'] != NULL ? $_SERVER['HTTP_REFERER'] : $base_url);
+    if (isset($_GET['destination']) && FALSE === url_is_external($_GET['destination'])) {
+      $redirect = $_GET['destination'];
+    }
+    elseif (NULL != $_SERVER['HTTP_REFERER']) {
+      $redirect = $_SERVER['HTTP_REFERER'];
+    }
+    else {
+      $redirect = $base_url . '/';
+    }
   }
 
   $website_description = variable_get('raven_website_description');
@@ -148,6 +156,7 @@ function raven_login($redirect = NULL) {
   $params['desc'] = !empty($website_description) ? $website_description : variable_get('site_name', $base_url);
   $params['params'] = url($redirect, array('absolute' => TRUE));
 
+  unset($_GET['destination']);
   drupal_goto(get_raven_url(), array('query' => $params), 303);
 }
 

--- a/tests/features/login.feature
+++ b/tests/features/login.feature
@@ -28,6 +28,20 @@ Feature: Login message
     And I press "Submit"
     Then I should be on "/user"
 
+  Scenario: After Raven login redirects to destination page
+    When I go to "/raven/login?destination=foo"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on "/foo"
+
+  Scenario: After Raven login redirects to the homepage when the destination page is not a relative URL
+    When I go to "/raven/login?destination=http://www.cam.ac.uk/"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on the homepage
+
   Scenario: Raven login available when in maintenance mode
     Given the "maintenance_mode" variable is set to "TRUE"
     And the "authenticated user" role has the "system" "access site in maintenance mode" permission


### PR DESCRIPTION
`drupal_goto()` will check to see if there's a `destination` query string parameter and will redirect there if present, so going to `/raven/login?destination=foo` will go to `foo` rather than to Raven. This stores the parameter as the redirect page, so that after going to Raven the user will go to `foo`.

Like `drupal_goto()` it makes sure that it's not an absolute URL.
