### PR TITLE
Make compatible with the r4032login module

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -156,6 +156,9 @@ function raven_login($redirect = NULL) {
   $params['desc'] = !empty($website_description) ? $website_description : variable_get('site_name', $base_url);
   $params['params'] = url($redirect, array('absolute' => TRUE));
 
+  // Remove any messages (such as 'You need to log in') to stop them appearing on the next page.
+  drupal_get_messages();
+
   unset($_GET['destination']);
   drupal_goto(get_raven_url(), array('query' => $params), 303);
 }
@@ -507,6 +510,7 @@ function user_raven_login_register($name) {
         switch (variable_get('user_register')) {
           case USER_REGISTER_ADMINISTRATORS_ONLY:
             drupal_set_message(t('Only site administrators can create accounts.'), 'error');
+            unset($_GET['destination']);
             drupal_goto(variable_get('raven_login_fail_redirect'));
             break;
           case USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL:
@@ -573,7 +577,8 @@ function user_raven_login_register($name) {
 
   global $user;
 
-  if (!$user->uid) {
+  if (!$user->uid || $user->status == 0) {
+    unset($_GET['destination']);
     drupal_goto(variable_get('raven_login_fail_redirect'));
   }
 }

--- a/tests/features/login.feature
+++ b/tests/features/login.feature
@@ -21,7 +21,8 @@ Feature: Login message
     Then I should be on "https://demo.raven.cam.ac.uk/auth/authenticate.html"
 
   Scenario: After Raven login redirects to current page
-    Given I am on "/user"
+    Given the "raven_override_administrator_approval" variable is set to "TRUE"
+    And I am on "/user"
     And I follow "log in with Raven"
     And I fill in "User-id" with "test0001"
     And I fill in "Password" with "test"
@@ -29,6 +30,7 @@ Feature: Login message
     Then I should be on "/user"
 
   Scenario: After Raven login redirects to destination page
+    Given the "raven_override_administrator_approval" variable is set to "TRUE"
     When I go to "/raven/login?destination=foo"
     And I fill in "User-id" with "test0001"
     And I fill in "Password" with "test"
@@ -36,6 +38,7 @@ Feature: Login message
     Then I should be on "/foo"
 
   Scenario: After Raven login redirects to the homepage when the destination page is not a relative URL
+    Given the "raven_override_administrator_approval" variable is set to "TRUE"
     When I go to "/raven/login?destination=http://www.cam.ac.uk/"
     And I fill in "User-id" with "test0001"
     And I fill in "Password" with "test"

--- a/tests/features/login_override.feature
+++ b/tests/features/login_override.feature
@@ -140,3 +140,39 @@ Feature: Login override
     And I should not see "Password" in the "#block-user-login" element
     When I follow "Log in with Raven"
     Then I should be on "https://demo.raven.cam.ac.uk/auth/authenticate.html"
+
+  Scenario: Compatible with r4032login module when can't create an account
+    Given the "r4032login" module is enabled
+    And the "raven_login_override" variable is set to "TRUE"
+    And the "user_register" variable is set to "0"
+    When I go to "/admin"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on the homepage
+    And I should not see "Access denied. You must log in to view this page."
+    And I should see "Only site administrators can create accounts."
+
+  Scenario: Compatible with r4032login module when need account to be confirmed
+    Given the "r4032login" module is enabled
+    And the "raven_login_override" variable is set to "TRUE"
+    And the "user_register" variable is set to "2"
+    When I go to "/admin"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on the homepage
+    And I should not see "Access denied. You must log in to view this page."
+    And I should see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+
+  Scenario: Compatible with r4032login module when can create account
+    Given the "r4032login" module is enabled
+    And the "raven_login_override" variable is set to "TRUE"
+    And the "user_register" variable is set to "1"
+    When I go to "/admin"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on "/admin"
+    And I should not see "Access denied. You must log in to view this page."
+    And I should see "You are not authorized to access this page."


### PR DESCRIPTION
(Note this includes the commit from #34 as it won't work without. That PR should be reviewed/merged first.)

The [Redirect 403 to User Login](https://www.drupal.org/project/r4032login) might be useful to redirect the user straight to Raven when they aren't authenticated, rather than having to go to an intermediate "You need to log in" page. This should fix the incompatibilities.
