### PR TITLE
user_save() is not called if the user is blocked

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -556,23 +556,20 @@ function user_raven_login_register($name) {
     drupal_alter('raven_login', $edit, $account);
   }
 
-  // Check if user is blocked
-  if (isset($account->name) && user_is_blocked($account->name)) {
+  $account = user_save($account, $edit);
+
+  if (FALSE === $account) {
+    drupal_set_message(t('Error saving user account.'), 'error');
+  }
+  elseif (user_is_blocked($account->name)) {
     drupal_set_message(t('The username @name is blocked.', array('@name' => $account->name)), 'error');
   }
   else {
-    // Save the account
-    $account = user_save($account, $edit);
-    if ($account != FALSE) {
-      user_set_authmaps($account, array('authname_raven' => $name));
+    user_set_authmaps($account, array('authname_raven' => $name));
 
-      // Log user in
-      $form_state['uid'] = $account->uid;
-      user_login_submit(array(), $form_state);
-    }
-    else {
-      drupal_set_message(t('Error saving user account.'), 'error');
-    }
+    // Log user in
+    $form_state['uid'] = $account->uid;
+    user_login_submit(array(), $form_state);
   }
 
   global $user;


### PR DESCRIPTION
`raven_auth()` gives other modules the opportunity to edit the user account, but `user_save()` is not actually called if the user is blocked. This changes it so `user_save()` is called before working out if the user can be logged in.
