### PR TITLE
Hide the user login block when on the backdoor

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -461,6 +461,19 @@ function raven_block_view_alter(&$data, $block) {
 }
 
 /**
+ * Implements hook_block_list_alter().
+ */
+function raven_block_list_alter(&$blocks) {
+  if(raven_backdoor_login_is_enabled() === TRUE && current_path() === 'user/backdoor/login') {
+    foreach($blocks as $key => $block) {
+      if($block->module === 'user' && $block->delta === 'login') {
+        unset($blocks[$key]);
+      }
+    }
+  }
+}
+
+/**
  * Is this a Raven user?
  *
  * @param StdClass $account

--- a/tests/features/login_override.feature
+++ b/tests/features/login_override.feature
@@ -141,6 +141,14 @@ Feature: Login override
     When I follow "Log in with Raven"
     Then I should be on "https://demo.raven.cam.ac.uk/auth/authenticate.html"
 
+  Scenario: User login block does not appear on backdoor
+    Given the "block" module is enabled
+    And the "raven_login_override" variable is set to "TRUE"
+    And the "raven_backdoor_login" variable is set to "TRUE"
+    And the "user" "login" block is in the "sidebar_first" region
+    When I go to "/user/backdoor/login"
+    Then I should not see a "#block-user-login" element
+
   Scenario: Compatible with r4032login module when can't create an account
     Given the "r4032login" module is enabled
     And the "raven_login_override" variable is set to "TRUE"


### PR DESCRIPTION
Fixes #36 by hiding the user login block when on the backdoor login page.
