### PR TITLE
Add Raven user Rules condition

### DIFF
--- a/raven.info
+++ b/raven.info
@@ -8,3 +8,4 @@ configure = admin/config/people/raven
 dependencies[] = user
 
 files[] = raven.module
+files[] = raven.rules.inc

--- a/raven.rules.inc
+++ b/raven.rules.inc
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Implements hook_rules_condition_info().
+ */
+function raven_rules_condition_info() {
+  return array(
+    'is_raven_user' => array(
+      'label' => t('User is a Raven user'),
+      'parameter' => array(
+        'account' => array('type' => 'user', 'label' => t('User')),
+      ),
+      'group' => t('User'),
+      'access callback' => 'rules_user_integration_access',
+      'base' => 'is_raven_user',
+    ),
+  );
+}

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -115,6 +115,7 @@ class FeatureContext extends RawMinkContext {
 
   /**
    * @Given /^I am logged in as the admin user$/
+   * @When /^I log in as the admin user$/
    */
   public function iAmLoggedInAsTheAdminUser() {
     $minkContext = $this->getMinkContext();
@@ -237,6 +238,12 @@ class FeatureContext extends RawMinkContext {
    */
   public function iLogInToRavenAs($username) {
     $minkContext = $this->getMinkContext();
+
+    $minkContext->visit('/');
+
+    if ($this->getSession()->getPage()->hasLink('Log out')) {
+      $minkContext->visit('/user/logout');
+    }
 
     $minkContext->visit('/raven/login');
     $minkContext->fillField('User-id', $username);

--- a/tests/features/rules.feature
+++ b/tests/features/rules.feature
@@ -1,0 +1,25 @@
+Feature: Raven rules
+
+  Scenario: Is Raven user condition
+    Given the "rules" module is enabled
+    And the "rules_admin" module is enabled
+    And the "raven_override_administrator_approval" variable is set to "TRUE"
+    And I am logged in as the admin user
+    And I am on "/admin/config/workflow/rules/reaction/add"
+    When I fill in "Name" with "Test Rule"
+    And I fill in "Machine-readable name" with "test_rule"
+    And I select "User has logged in" from "React on event"
+    And I press "Save"
+    And I follow "Add condition"
+    And I select "User is a Raven user" from "Select the condition to add"
+    And I press "Continue"
+    And I press "Save"
+    And I follow "Add action"
+    And I select "Show a message on the site" from "Select the action to add"
+    And I press "Continue"
+    And I fill in "Value" with "Hello Raven user"
+    And I press "Save"
+    When I log in to Raven as "test0001"
+    Then I should see "Hello Raven user"
+    When I log in as the admin user
+    Then I should not see "Hello Raven user"


### PR DESCRIPTION
This add a Rules condition saying whether a user is a Raven user or not. This can then be used to automatically give a Raven user a role etc.
