### PR TITLE
Don't add language prefix on destination path

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -154,7 +154,7 @@ function raven_login($redirect = NULL) {
   $params['ver'] = '3';
   $params['url'] = $base_url . '/';
   $params['desc'] = !empty($website_description) ? $website_description : variable_get('site_name', $base_url);
-  $params['params'] = url($redirect, array('absolute' => TRUE));
+  $params['params'] = url($redirect, array('absolute' => TRUE, 'language' => (object) array('language' => FALSE)));
 
   // Remove any messages (such as 'You need to log in') to stop them appearing on the next page.
   drupal_get_messages();

--- a/tests/features/login_override.feature
+++ b/tests/features/login_override.feature
@@ -51,6 +51,18 @@ Feature: Login override
     | /usEr/register |
     | /usEr/login    |
 
+  Scenario: Doesn't double-language-prefix a path when using destination
+    Given the "raven_login_override" variable is set to "TRUE"
+    And the "user_register" variable is set to "1"
+    And the "i18n" module is enabled
+    And Spanish is enabled
+    When I go to "/es/user/login?destination=es/admin"
+    Then I should be on "https://demo.raven.cam.ac.uk/auth/authenticate.html"
+    And I fill in "User-id" with "test0001"
+    And I fill in "Password" with "test"
+    And I press "Submit"
+    Then I should be on "/es/admin"
+
   Scenario Outline: Overrides user pages when in maintenance mode
     Given the "maintenance_mode" variable is set to "TRUE"
     And the "raven_login_override" variable is set to "TRUE"


### PR DESCRIPTION
If language prefixes are being used, the path to go to after a successful log in can be double prefixed (eg going to `es/admin` and being sent to the log in page results in `es/es/admin`). This stops it.
