### PR TITLE
Stop double message

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -585,7 +585,7 @@ function user_raven_login_register($name) {
   if (FALSE === $account) {
     drupal_set_message(t('Error saving user account.'), 'error');
   }
-  elseif (user_is_blocked($account->name)) {
+  elseif (FALSE === isset($status) && user_is_blocked($account->name)) {
     drupal_set_message(t('The username @name is blocked.', array('@name' => $account->name)), 'error');
   }
   else {

--- a/tests/features/account_creation.feature
+++ b/tests/features/account_creation.feature
@@ -4,6 +4,7 @@ Feature: Account creation
     Given the "user_register" variable is set to "2"
     When I log in to Raven as "test0001"
     Then I should see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+    And I should not see "The username test0001 is blocked"
     And I should not see "Log out"
 
   Scenario: Can create accounts when allowed
@@ -12,11 +13,15 @@ Feature: Account creation
     When I log in to Raven as "test0001"
     Then I should see "Log out"
     And I should see an "notice" "raven" Watchdog message "New user: test0001 (test0001@cam.ac.uk)."
+    And I should not see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+    And I should not see "The username test0001 is blocked"
 
   Scenario: Can't create accounts when administrators only
     Given the "user_register" variable is set to "0"
     When I log in to Raven as "test0001"
     Then I should see "Only site administrators can create accounts."
+    And I should not see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+    And I should not see "The username test0001 is blocked"
     And I should not see "Log out"
 
   Scenario: Takes over existing accounts
@@ -25,6 +30,8 @@ Feature: Account creation
     When I log in to Raven as "test0001"
     Then I should see "Log out"
     And I should see an "notice" "raven" Watchdog message "Migrated user: test0001 (test0001@example.com)."
+    And I should not see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."
+    And I should not see "The username test0001 is blocked"
 
   Scenario: Can't log in to existing blocked account
     Given the "dblog" module is enabled
@@ -33,3 +40,4 @@ Feature: Account creation
     When I log in to Raven as "test0001"
     Then I should see "The username test0001 is blocked"
     And I should see an "notice" "raven" Watchdog message "Migrated user: test0001 (test0001@example.com)."
+    And I should not see "Thank you for applying for an account. Your account is currently pending approval by the site administrator."


### PR DESCRIPTION
#37 changed where `user_save()` was called, causing a double message when account creation approval is required (both 'Thank you for applying for an account. Your account is currently pending approval by the site administrator.' then 'The username test0001 is blocked'.).

This fixes it.