### PR TITLE
Ensure that the path that will ultimately be passed to drupal_encode_…

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -154,7 +154,8 @@ function raven_login($redirect = NULL) {
   $params['ver'] = '3';
   $params['url'] = $base_url . '/';
   $params['desc'] = !empty($website_description) ? $website_description : variable_get('site_name', $base_url);
-  $params['params'] = url($redirect, array('absolute' => TRUE, 'language' => (object) array('language' => FALSE)));
+  // The options passed to drupal_goto() must not be URI-encoded because they ultimately get passed to drupal_encode_path()
+  $params['params'] = rawurldecode(url($redirect, array('absolute' => TRUE, 'language' => (object) array('language' => FALSE))));
 
   // Remove any messages (such as 'You need to log in') to stop them appearing on the next page.
   drupal_get_messages();


### PR DESCRIPTION
…path() is not URI-encoded.

With reference to issue #48 . (N.B. I've a feeling this might resolve #46 too)

I think this /may/ have been introduced as a result of https://github.com/misd-service-development/drupal-raven/commit/3fa5b82ef68ce4379302739b6c7fbdcdb0931576#diff-a60b146b7380729dffb79ce6bbdedbe8

I think the issue is the drupal_goto call at https://github.com/misd-service-development/drupal-raven/blob/75fb441abcc565b2478437bd27e732d6408b83aa/raven.module#L163  drupal_goto() in turn just calls url(), and that in turn builds an internal variable called $path and passes it to drupal_encode_path() . Per https://api.drupal.org/api/drupal/includes!common.inc/function/drupal_encode_path/7.x , "a path passed to that function should not be encoded in advance"