### PR TITLE
Adds PHP8 compatibility changes

### DIFF
--- a/raven.module
+++ b/raven.module
@@ -378,7 +378,9 @@ function raven_init() {
 function raven_signature_check($data, $sig) {
   $key = openssl_pkey_get_public(get_raven_pubkey());
   $result = openssl_verify(rawurldecode($data), raven_signature_decode(rawurldecode($sig)), $key);
-  openssl_free_key($key);
+  if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+    openssl_free_key($key);
+  }
   switch ($result) {
     case 1:
       return TRUE;
@@ -526,7 +528,7 @@ function user_raven_login_register($name) {
   $edit = array();
   $account = user_external_load($name);
 
-  if (variable_get('raven_logout_on_browser_close', TRUE) == TRUE) {
+  if (variable_get('raven_logout_on_browser_close', TRUE) && session_status() !== PHP_SESSION_ACTIVE) {
     ini_set('session.cookie_lifetime', 0);
   }
 

--- a/tests/features/bootstrap/functions.php
+++ b/tests/features/bootstrap/functions.php
@@ -182,7 +182,9 @@ Y6iyl0/GyBRzAXYemQJAVeChw15Lj2/uE7HIDtkqd8POzXjumOxKPfESSHKxRGnP
 
   openssl_sign($data, $signature, $pkeyid);
 
-  openssl_free_key($pkeyid);
+  if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+    openssl_free_key($pkeyid);
+  }
 
   $signature =
     preg_replace(


### PR DESCRIPTION
openssl_free_key not deprecated in PHP8 and no longer required
https://www.php.net/manual/en/function.openssl-free-key.php

Adds additional check in function user_raven_login_register before ini_set. If the session has already started the ini cannot be modified, so if statement now also checks if the session has started yet
